### PR TITLE
Remove debugging `print()` from `TS3Event` class

### DIFF
--- a/Events.py
+++ b/Events.py
@@ -66,7 +66,6 @@ class TS3Event():
         :return: Attribute value string
         :rtype: str
         """
-        print(self._data, item)
         return self._data[item]
 
 


### PR DESCRIPTION
Seems like as this is only for debugging purposes.